### PR TITLE
Derive Copy+Clone for Interrupt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub const NVIC_PRIO_BITS: u8 = 3;
 /// only contain the variants from `GPIOA` to `GPIOG`.
 // NOTE: See Table 2-9 Interrupts. Section 2.5.2 "Exception types"
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub enum Interrupt {
     /// GPIO Port A
     GPIOA,


### PR DESCRIPTION
The `NVIC.pend` method in cortex-m 0.7 wants an `InterruptNumber = Nr + Copy`. This change seems to be required to bump cortex-m in `cortex-m-rtic`.