### PR TITLE
Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["arm", "cortex-m"]
 license = "MIT OR Apache-2.0"
 name = "lm3s6965"
 repository = "https://github.com/japaric/lm3s6965"
-version = "0.1.3"
+version = "0.2.0"
 
 [dependencies]
-bare-metal = "0.2.3"
+cortex-m = "0.7.0"
 
 [dependencies.cortex-m-rt]
 features = ["device"]
-version = "0.6.5"
+version = "0.6.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![no_std]
 
 pub use self::Interrupt as interrupt;
-use bare_metal::Nr;
+use cortex_m::interrupt::InterruptNumber;
 pub use cortex_m_rt::interrupt;
 
 /// Number of bits available in the NVIC for configuring priority

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub const NVIC_PRIO_BITS: u8 = 3;
 /// only contain the variants from `GPIOA` to `GPIOG`.
 // NOTE: See Table 2-9 Interrupts. Section 2.5.2 "Exception types"
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub enum Interrupt {
     /// GPIO Port A
     GPIOA,


### PR DESCRIPTION
This would be a follow-up to https://github.com/japaric/lm3s6965/pull/4.

I understand the alternative would be to bump only the patch version, and cortex-m-rt to the latest non-yanked version. But in light of the bare-metal 1.0 release, and to minimize future releases, it might be preferable to get rid of pre-1.0 bare-metal?